### PR TITLE
Allow coords with elevation value

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,8 +30,11 @@
     return temp;
   }
 
+  /*
+   * Check coords in form of [x, y] or [x, y, z]
+   */
   function isValidCoord(coord) {
-    return coord && coord.length === 2 &&
+    return coord && coord.length >= 2 &&
       typeof coord[0] === 'number' &&
         typeof coord[1] === 'number';
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gbify-geojson",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Reproject GeoJSON between OSGB36 GB National Grid and WGS84",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -21,6 +21,27 @@ var point = {
   }
 };
 
+var pointWithElevation = {
+  OSGB36: {
+    "type": "Point",
+    "properties": {
+      "hello": "world"
+    },
+    "coordinates": [
+      437324.22, 115385.91, 150
+    ]
+  },
+  WGS84: {
+    "type": "Point",
+    "properties": {
+      "hello": "world"
+    },
+    "coordinates": [
+      -1.47019386, 50.9367169, 150
+    ]
+  }
+};
+
 var lineString = {
   OSGB36: {
     "type": "Feature",
@@ -119,6 +140,7 @@ var featureCollectionWithCrs = {
 
 module.exports = {
   point: point,
+  pointWithElevation: pointWithElevation,
   lineString: lineString,
   featureCollection: featureCollection,
   featureCollectionWithCrs: featureCollectionWithCrs,

--- a/test/gbify-geojson.tests.js
+++ b/test/gbify-geojson.tests.js
@@ -4,14 +4,14 @@ var expect = require('expect.js'),
 
 // todo fix these
 function isValidCoord(coord) {
-  return coord && coord.length === 2 &&
+  return coord && coord.length >= 2 &&
     typeof coord[0] === 'number' &&
       typeof coord[1] === 'number';
 }
 
 function closeEnough(actualCoords, expectedCoords, precision) {
   //console.log([actualCoords, expectedCoords, precision])
-  return (actualCoords.length === 2 &&
+  return (actualCoords.length >= 2 &&
     Math.abs(actualCoords[0] - expectedCoords[0]) < precision &&
       Math.abs(actualCoords[1] - expectedCoords[1]) < precision
   );
@@ -41,6 +41,13 @@ describe('toOSGB36', function () {
       var transformed = gbgeojsonify.toOSGB36(FIXTURES.point.WGS84);
       expect(
         closeEnough(transformed.coordinates, FIXTURES.point.OSGB36.coordinates, 0.02)
+      ).to.be(true);
+    });
+
+    it('transforms Point with elevation value', function() {
+      var transformed = gbgeojsonify.toOSGB36(FIXTURES.pointWithElevation.WGS84);
+      expect(
+        closeEnough(transformed.coordinates, FIXTURES.pointWithElevation.OSGB36.coordinates, 0.02)
       ).to.be(true);
     });
 
@@ -89,6 +96,13 @@ describe('toWGS84', function () {
       var transformed = gbgeojsonify.toWGS84(FIXTURES.point.OSGB36);
       expect(
         closeEnough(transformed.coordinates, FIXTURES.point.WGS84.coordinates, 1e-6)
+      ).to.be(true);
+    });
+
+    it('transforms point with elevation value', function() {
+      var transformed = gbgeojsonify.toWGS84(FIXTURES.pointWithElevation.OSGB36);
+      expect(
+        closeEnough(transformed.coordinates, FIXTURES.pointWithElevation.WGS84.coordinates, 1e-6)
       ).to.be(true);
     });
 


### PR DESCRIPTION
Check that coords are in the form of `[x, y]` or `[x, y, something]` and let proj4 handle it. This allows triples with elevation value instead of breaking.
